### PR TITLE
Adds JPA entities for case management

### DIFF
--- a/src/main/java/com/group3/MockProject/entity/Case.java
+++ b/src/main/java/com/group3/MockProject/entity/Case.java
@@ -1,0 +1,53 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "case")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class Case {
+    @Id
+    @Column(name = "case_id", nullable = false)
+    private String caseId;
+
+    @Column(name = "case_name", nullable = false)
+    private String caseName;
+
+    @Column(name = "type_case", nullable = true)
+    private String typeCase;
+    // nếu sau này muốn mapping enum hoặc lookup table:
+    // @Enumerated(EnumType.STRING)
+    // private CaseType typeCase;
+
+    @Column(name = "severity", nullable = false)
+    private Integer severity;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+    // tương tự có thể dùng enum:
+    // @Enumerated(EnumType.STRING)
+    // private CaseStatus status;
+
+    @Column(name = "summary", columnDefinition = "TEXT", nullable = true)
+    private String summary;
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/com/group3/MockProject/entity/CaseResult.java
+++ b/src/main/java/com/group3/MockProject/entity/CaseResult.java
@@ -1,0 +1,50 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "case_result")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class CaseResult {
+    @Id
+    @Column(name = "case_result_id", nullable = false)
+    private String caseResultId;
+
+    // --- foreign key sang CASE (nếu cần mapping quan hệ, sẽ dùng @ManyToOne) ---
+    @Column(name = "case_id", nullable = false)
+    private String caseId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "case_id", insertable = false, updatable = false)
+    // private Case parentCase;
+
+    @Column(name = "report_time", nullable = false)
+    private LocalDateTime reportTime;
+
+    @Column(name = "report_analyst", nullable = false)
+    private String reportAnalyst;
+
+    @Column(name = "summary", columnDefinition = "TEXT", nullable = false)
+    private String summary;
+
+    @Column(name = "identify_motive", nullable = true)
+    private String identifyMotive;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/com/group3/MockProject/entity/Evidence.java
+++ b/src/main/java/com/group3/MockProject/entity/Evidence.java
@@ -1,0 +1,67 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "evidence")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class Evidence {
+    @Id
+    @Column(name = "evidence_id", nullable = false)
+    private String evidenceId;
+
+    // --- FK sang các bảng khác (khi cần mapping quan hệ, bỏ comment @ManyToOne) ---
+    @Column(name = "measure_survey_id", nullable = false)
+    private Long measureSurveyId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "measure_survey_id", insertable = false, updatable = false)
+    // private MeasureSurvey measureSurvey;
+
+    @Column(name = "warrant_result_id", nullable = false)
+    private Long warrantResultId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "warrant_result_id", insertable = false, updatable = false)
+    // private WarrantResult warrantResult;
+
+    @Column(name = "report_id", nullable = false)
+    private Long reportId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "report_id", insertable = false, updatable = false)
+    // private Report report;
+
+    @Column(name = "collected_by", nullable = false)
+    private Long collectedBy;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "collected_by", insertable = false, updatable = false)
+    // private User collector;
+
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "collected_at", nullable = false)
+    private LocalDateTime collectedAt;
+
+    @Column(name = "current_location", nullable = false)
+    private String currentLocation;
+
+    @Column(name = "attached_file", columnDefinition = "TEXT", nullable = true)
+    private String attachedFile;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+}

--- a/src/main/java/com/group3/MockProject/entity/PhysicalInvest.java
+++ b/src/main/java/com/group3/MockProject/entity/PhysicalInvest.java
@@ -1,0 +1,35 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "physical_invest")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class PhysicalInvest {
+    @Id
+    @Column(name = "evidence_id", nullable = false)
+    private String evidenceId;
+
+    // --- foreign key sang bảng khác (nếu cần mapping quan hệ, bỏ comment @ManyToOne) ---
+    // @Column(name = "case_id", nullable = false)
+    // private Long caseId;     // FK
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "case_id", insertable = false, updatable = false)
+    // private CaseEntity caseEntity;
+
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = true)
+    private String imageUrl;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/com/group3/MockProject/entity/Timeline.java
+++ b/src/main/java/com/group3/MockProject/entity/Timeline.java
@@ -1,0 +1,49 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "timeline")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class Timeline {
+    @Id
+    @Column(name = "timeline_id", nullable = false)
+    private String timelineId;
+
+    // --- foreign key sang CASE_RESULT (nếu cần mapping quan hệ, sẽ dùng @ManyToOne) ---
+    @Column(name = "case_result_id", nullable = false)
+    private Long caseResultId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "case_result_id", insertable = false, updatable = false)
+    // private CaseResult caseResult;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = true)
+    private LocalDateTime endTime;
+
+    @Column(name = "attached_file", columnDefinition = "TEXT", nullable = true)
+    private String attachedFile;
+
+    @Column(name = "notes", columnDefinition = "TEXT", nullable = true)
+    private String notes;
+
+    @Column(name = "activity", nullable = false)
+    private String activity;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+}

--- a/src/main/java/com/group3/MockProject/entity/Warrant.java
+++ b/src/main/java/com/group3/MockProject/entity/Warrant.java
@@ -1,0 +1,44 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "warrant")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class Warrant {
+    @Id
+    @Column(name = "warrant_id", nullable = false)
+    private String warrantId;
+
+    // --- khóa ngoại sang CASE (nếu cần mapping quan hệ, bỏ comment @ManyToOne) ---
+    @Column(name = "case_id", nullable = false)
+    private Long caseId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "case_id", insertable = false, updatable = false)
+    // private CaseEntity caseEntity;
+
+    @Column(name = "warrant_name", nullable = false)
+    private String warrantName;
+
+    @Column(name = "attached_file", columnDefinition = "TEXT", nullable = true)
+    private String attachedFile;
+
+    @Column(name = "time_publish", nullable = false)
+    private LocalDateTime timePublish;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+}

--- a/src/main/java/com/group3/MockProject/entity/WarrantResult.java
+++ b/src/main/java/com/group3/MockProject/entity/WarrantResult.java
@@ -1,0 +1,46 @@
+package com.group3.MockProject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "warrant_result")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class WarrantResult {
+    @Id
+    @Column(name = "warrant_result_id", nullable = false)
+    private String warrantResultId;
+
+    // --- foreign key sang WARRANT (nếu cần mapping quan hệ, bỏ comment @ManyToOne) ---
+    @Column(name = "warrant_id", nullable = false)
+    private Long warrantId;
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "warrant_id", insertable = false, updatable = false)
+    // private Warrant warrant;
+
+    @Column(name = "police_response", nullable = false)
+    private String policeResponse;
+
+    @Column(name = "location", nullable = false)
+    private String location;
+
+    @Column(name = "notes", columnDefinition = "TEXT", nullable = true)
+    private String notes;
+
+    @Column(name = "time_active", nullable = false)
+    private LocalDateTime timeActive;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+}


### PR DESCRIPTION
This pull request introduces the JPA entities required for managing cases within the application.

It defines the data structures and database mappings for:
- Cases
- Case Results
- Evidence
- Physical Investments
- Timelines
- Warrants
- Warrant Results

These entities will serve as the foundation for implementing case management functionalities.